### PR TITLE
docs: add USAGE.md and docs/ deep-dive reference

### DIFF
--- a/USAGE.md
+++ b/USAGE.md
@@ -1,0 +1,293 @@
+# nisprog — USAGE
+
+## Purpose
+
+nisprog is an open-source Nissan ECU flash tool for K-line (ISO 14230 /
+KWP2000) equipped ECUs. It can dump ROM contents, verify ROM differences,
+and reflash ECUs using selective block flashing. It runs as an interactive
+CLI, uses freediag for K-line transport, and npkern SH2 kernels for fast
+flash and dump operations.
+
+**Supported ECU families:** SH7051 (256 KB), SH7055 (512 KB), SH7058 (1 MB).
+
+**Deep-dive docs** (load as needed):
+
+- [`docs/set_reference.md`](docs/set_reference.md) — interface names, dumbopts flags, l1/l2protocol, initmode, module addresses
+- [`docs/security_access.md`](docs/security_access.md) — `gk` vs `setkeys`, s27-only lookup, how security access works
+- [`docs/crash_recovery.md`](docs/crash_recovery.md) — recovering from nisprog crash, bad flash, kernel hang
+- [`docs/re_workflow.md`](docs/re_workflow.md) — using nisprog for reverse engineering (watch, diag sr, partial dumps)
+- [`docs/debug.md`](docs/debug.md) — debug submenu, flag values, l0test, diagnosing comms issues
+
+---
+
+## Starting nisprog
+
+```
+nisprog [config_file]
+```
+
+Loads `nisprog.ini` from the current directory if no file is given. All
+commands are entered at the `nisprog>` prompt.
+
+---
+
+## Connection Settings — Two Syntaxes
+
+### At the interactive prompt
+
+```
+set interface DUMB          # adapter driver (DUMB for any simple K-line cable)
+set port \\.\COM19          # Windows serial port — Linux: /dev/ttyUSB0
+set dumbopts 0x68           # MEC07 confirmed: MAN_BREAK + BLOCKDUPLEX + FAST_BREAK
+set l1protocol ISO14230     # set both l1 AND l2 explicitly for MEC07
+set l2protocol iso14230     # KWP2000 framing — required for all Nissan ECU commands
+set initmode fast           # ISO 14230 fast init — correct for Nissan MEC07
+set testerid 0xfc           # source address placed in K-line frame headers
+set destaddr 0x10           # destination: 0x10 = powertrain ECM
+set addrtype phys           # physical addressing: targets one module only
+up                          # bring K-line link up
+nc                          # connect — ECUID is printed automatically on success
+```
+
+### In nisprog.ini
+
+`set` on its own line enters the set submenu. All lines that follow are bare
+subcommands without the `set` prefix — they run in the submenu context until
+`up` exits it.
+
+```ini
+# Two-syntax rule: "set" alone opens the submenu.
+# Inside the submenu, write the subcommand name directly — no "set" prefix.
+# At the interactive nisprog> prompt you would type "set l2protocol iso14230";
+# here, inside the submenu block, it is just "l2protocol iso14230".
+set
+port \\.\COM19              # serial port — adjust COM number for your adapter
+interface DUMB              # DUMB = any simple K-line cable (not ELM327)
+dumbopts 0x68               # MEC07 confirmed: MAN_BREAK + BLOCKDUPLEX + FAST_BREAK
+                            # (try 0x48 first if 0x68 fails on your adapter)
+l1protocol ISO14230         # set both l1 AND l2 explicitly for MEC07 — do not rely on auto-select
+l2protocol iso14230         # KWP2000 framing — required for Nissan
+initmode fast               # ISO 14230 fast init for MEC07
+testerid 0xfc               # tester source address (standard)
+destaddr 0x10               # ECM address — change to 0x15/0x35 for ABS/SRS
+addrtype phys               # physical: address one module, not broadcast
+up                          # exit submenu and bring K-line link up
+```
+
+Use `set show` to verify all current values after loading a config file.
+
+---
+
+## Set — Quick Reference
+
+| Setting | Default | Common values |
+|---------|---------|---------------|
+| `interface` | `DUMB` | `DUMB` (most cables), `ELM` (ELM327) — see [docs/set_reference.md](docs/set_reference.md) |
+| `port` | — | `\\.\COM19` (Win), `/dev/ttyUSB0` (Linux) |
+| `dumbopts` | `0x48` | `0x48` (USB K-line), `0x49` (L-line init), `0x68` (alt fast break) |
+| `l1protocol` | auto | `ISO14230` for Nissan K-line; rarely set explicitly |
+| `l2protocol` | `iso14230` | `iso14230` (Nissan), `raw` (Subaru SSM) |
+| `initmode` | `fast` | `fast` (MEC07), `5baud` (older ECUs) |
+| `testerid` | `0xfc` | `0xfc` (standard) |
+| `destaddr` | `0x10` | `0x10` (ECM), `0x15` (ABS), `0x35` (SRS) — see [docs/set_reference.md](docs/set_reference.md) |
+| `addrtype` | `phys` | `phys` (single module), `func` (broadcast scan) |
+| `speed` | auto | Only change to `62500` for kernel crash reconnect |
+
+---
+
+## Commands — Quick Reference
+
+### Connection
+
+| Command | Description |
+|---------|-------------|
+| `nc` / `npconn` | Connect to Nissan ECU. Prints ECUID on success. |
+| `spconn` | Connect to Subaru ECU (SSM). |
+| `npdisc` / `nd` | Disconnect (does not reset ECU if kernel is running). |
+| `source <file>` | Execute commands from a file. |
+| `quit` | Exit nisprog. |
+
+### Security and identification
+
+`nc` prints the ECUID automatically — no separate command needed.
+
+| Command | Description |
+|---------|-------------|
+| `gk` | Guess security key from bundled DB. Prints s27k/s36k on success. |
+| `setkeys <s27k> [s36k]` | Set keys manually. s36k optional — omit to look up from DB by s27k. See [docs/security_access.md](docs/security_access.md). |
+| `setdev <device>` | Set flash device: `7051` (256 KB), `7055` (512 KB), `7058` (1 MB). **Required before dump or flash.** |
+| `writevin <vin>` | Write VIN string to EEPROM. |
+
+### Dump
+
+| Command | Description |
+|---------|-------------|
+| `dm <file> 0 0` | Dump entire ROM (size from `setdev`). |
+| `dm <file> <addr> <len>` | Dump `len` bytes from `addr`. |
+| `dm <file> <addr> <len> eep` | Dump from EEPROM (requires `npconf eepr <addr>`). |
+
+Dump without kernel is slow. Run `runkernel` first.
+
+### Flash kernel
+
+| Command | Description |
+|---------|-------------|
+| `runkernel <file>` | Upload and start npkern in ECU RAM (Nissan). |
+| `sprunkernel <file>` | Upload and start SSM kernel (Subaru). |
+| `initk` | Re-initialise already-running kernel (use after crash reconnect). |
+| `stopkernel` | Stop kernel and restart ECU (power cycle equivalent). |
+| `kspeed <baud>` | Change kernel baud rate. Valid: 62500, 31250, 25000. |
+| `npconf <param> [val]` | Tune timing/protocol. `npconf ?` lists all params. |
+
+**Kernel file selection (`setdev 7055` — pick by flash cell):**
+
+| File | Cell | ECU examples |
+|------|------|--------------|
+| `npk_SH7051.bin` | SH7051 | Older Nissan (`setdev 7051`) |
+| `npk_SH7055_35.bin` | 350 nm | MEC07-370/390 (VG33/VG33ER) — most mid-2000s Nissan |
+| `npk_SH7055_18.bin` | 180 nm | Some SH7055S-based Nissan |
+| `npk_SH7058.bin` | 180 nm | Newer Nissan (`setdev 7058`) |
+
+### Flash / verify
+
+| Command | Description |
+|---------|-------------|
+| `flverif <file>` | Compare ECU flash to file — lists changed blocks, no writes. |
+| `flrom <file> [orig]` | Flash ROM. Detects changed blocks by CRC. |
+| `flblock <file> <blockno> [Y]` | Flash one block. Add `Y` to skip confirmation. |
+
+> `flverif` / `flrom` / `flblock` require npkern running.
+
+### Diagnostics
+
+| Command | Description |
+|---------|-------------|
+| `watch <addr>` | Poll and display 4 bytes at address continuously. Enter to stop. See [docs/re_workflow.md](docs/re_workflow.md). |
+| `diag sr <byte...>` | Send raw KWP2000 bytes to ECU, print response. |
+| `debug <subcommand>` | K-line tracing and adapter tests. See [docs/debug.md](docs/debug.md). |
+
+---
+
+## Workflow INI Files
+
+### `nisprog_dump.ini`
+
+```ini
+# nisprog_dump.ini — full ROM dump
+# Edit COM port and kernel path before use.
+# Recommended: connect a battery tender/charger before starting — a dump takes
+# ~10 minutes and a low-voltage dropout mid-session will corrupt the kernel state.
+# If the dump is taking more than ~1 hour, stop it and verify setdev matches your
+# ECU (7051=256KB, 7055=512KB, 7058=1MB). Reading past the actual ROM size causes
+# nisprog to round-robin and become extremely slow.
+# Run: nisprog nisprog_dump.ini
+
+set                      # enter set submenu (no "set" prefix on lines below)
+port \\.\COM19           # serial port — Windows COM port for K-line adapter
+interface DUMB           # driver — DUMB for any simple K-line cable
+dumbopts 0x68            # MEC07 confirmed: MAN_BREAK + BLOCKDUPLEX + FAST_BREAK
+l1protocol ISO14230      # set both l1 AND l2 explicitly for MEC07
+l2protocol iso14230      # KWP2000 framing — required for all Nissan ECU commands
+initmode fast            # ISO 14230 fast init — correct for MEC07
+testerid 0xfc            # source address in K-line frames
+destaddr 0x10            # destination — 0x10 = powertrain ECM
+addrtype phys            # physical addressing (target one module, not broadcast)
+up                       # exit set submenu and bring K-line link up
+
+nc                       # connect to ECU — prints ECUID on success
+gk                       # guess security key — RECORD the s27k/s36k printed here
+setdev 7055              # set flash device type (7051/7055/7058 — must match ECU)
+
+# Load flash kernel for fast dump (kernel stays in RAM, does not modify flash)
+runkernel npkern\npk_SH7055_35.bin
+
+dm backup.bin 0 0        # dump entire ROM to backup.bin (size from setdev)
+
+stopkernel               # stop kernel — resets ECU (clears self-learn, DTCs)
+npdisc                   # disconnect from K-line
+```
+
+### `nisprog_flash.ini`
+
+```ini
+# nisprog_flash.ini — ROM verification and flash
+# BEFORE USE:
+#   1. Connect a battery charger — flashing REQUIRES stable voltage (>12.5V).
+#      A dropout mid-flash leaves the ECU in a partially written state.
+#   2. Edit COM port and kernel path
+#   3. Replace setkeys values with s27k/s36k from your gk run
+#   4. Replace patched_rom.bin with your ROM filename
+#   5. Run: nisprog nisprog_flash.ini
+
+set                      # enter set submenu
+port \\.\COM19           # serial port
+interface DUMB           # adapter driver
+dumbopts 0x68            # MEC07 confirmed: MAN_BREAK + BLOCKDUPLEX + FAST_BREAK
+l1protocol ISO14230      # set both l1 AND l2 explicitly for MEC07
+l2protocol iso14230      # KWP2000 — required for Nissan
+initmode fast            # fast init for MEC07
+testerid 0xfc            # tester source address
+destaddr 0x10            # ECM target address
+addrtype phys            # physical (single-module) addressing
+up                       # exit submenu, bring link up
+
+nc                       # connect — confirms communication before proceeding
+setkeys 0xXXXXXXXX 0xXXXXXXXX  # supply keys from prior gk run (s27k then s36k)
+setdev 7055              # flash device type — must match ECU
+runkernel npkern\npk_SH7055_35.bin
+
+flverif patched_rom.bin  # dry run — lists changed blocks without writing anything
+flrom patched_rom.bin    # flash — prompts for confirmation per block
+
+stopkernel               # reset ECU (exits kernel, starts ECU from flash)
+npdisc                   # disconnect
+```
+
+---
+
+## Typical Workflow (interactive)
+
+```
+# 1. Set up connection
+set interface DUMB
+set port \\.\COM19
+set dumbopts 0x48
+set l2protocol iso14230
+set initmode fast
+set testerid 0xfc
+set destaddr 0x10
+set addrtype phys
+up
+nc                             # ECUID printed here
+
+# 2. Security + device
+gk                             # record s27k/s36k
+setdev 7055
+
+# 3. Kernel
+runkernel npkern\npk_SH7055_35.bin
+
+# 4. Dump (backup)
+dm backup.bin 0 0
+
+# 5. Verify patched ROM
+flverif patched_rom.bin
+
+# 6. Flash
+flrom patched_rom.bin
+
+# 7. Finish
+stopkernel
+npdisc
+quit
+```
+
+---
+
+## Quick notes
+
+- `nc` prints the ECUID automatically — no separate command needed.
+- `setdev` accepts `7051`, `7055`, `7058` only — `7055_18`/`7055_35` are kernel filenames.
+- `stopkernel` is a power cycle — self-learn (LTFT, idle, VVT, knock) is lost.
+- Spaces in file paths break `runkernel` — use paths with no spaces.
+- `ssmprog.ini` / `SubaruSIDs.txt` are for Subaru SSM only — not Nissan.

--- a/docs/crash_recovery.md
+++ b/docs/crash_recovery.md
@@ -1,0 +1,156 @@
+# nisprog — Crash Recovery
+
+## Key principle
+
+**The npkern kernel runs entirely in ECU RAM.** As long as ECU power is
+maintained, the kernel keeps running even if nisprog crashes, the PC
+reboots, or the USB cable is disconnected. You can reconnect and continue
+without reuploading the kernel.
+
+**Never cut ECU power during or after a flash that has not been completed.**
+If power is lost mid-flash with changed blocks not yet written, the ECU
+ROM is in an inconsistent state and may not boot.
+
+---
+
+## Scenario 1: nisprog crashed, kernel still running
+
+The most common scenario — nisprog exits or the PC crashes, but the ECU
+has been on continuously.
+
+```
+# 1. Reopen nisprog
+nisprog nisprog_dump.ini    # or just: nisprog
+
+# 2. Set comms to kernel baud rate (NOT the default K-line 10400)
+set speed 62500             # kernel operates at 62500 bps
+
+# 3. Reconnect — skip nc, go straight to kernel init
+nc                          # establishes the L2 session
+initk                       # re-initialises kernel comms without reuploading
+
+# 4. Re-supply security keys (session may not be cached)
+setkeys 0xXXXXXXXX 0xXXXXXXXX
+
+# 5. Continue
+setdev 7055
+# Verify the kernel is working before attempting any flash
+dm verify_test.bin 0 0x1000    # short dump — confirms stable comms
+```
+
+If `initk` succeeds and the dump completes cleanly, it is safe to continue
+flashing or dumping.
+
+---
+
+## Scenario 2: flash interrupted mid-write
+
+If a flash was interrupted (nisprog crash, USB disconnect, PC crash) while
+`flrom` was running:
+
+1. **Keep ECU power on** — do not turn off the ignition.
+2. Reconnect as in Scenario 1 (`nc` → `initk`).
+3. Verify kernel comms with a short dump before anything else.
+4. Run `flverif patched_rom.bin` to identify which blocks were written and
+   which were not.
+5. Run `flrom patched_rom.bin` again — nisprog will detect already-correct
+   blocks and skip them, only rewriting those that still differ.
+
+```
+nc
+initk
+setkeys 0xXXXXXXXX 0xXXXXXXXX
+setdev 7055
+dm verify.bin 0 0x1000           # confirm kernel is stable
+flverif patched_rom.bin           # see which blocks are still wrong
+flrom patched_rom.bin             # rewrite only changed blocks
+stopkernel
+```
+
+---
+
+## Scenario 3: kernel crashed or hung
+
+If `initk` fails or the kernel is not responding (timeout errors, no response
+to any command):
+
+1. Attempt to purge the kernel's buffer — open a terminal (e.g. RealTerm) on
+   the same COM port at 62500 bps and send several `0x00` bytes until you get
+   a `0x7F NN` negative response. This re-syncs the framing.
+2. If purge succeeds, try `initk` again in nisprog.
+3. If the kernel cannot be recovered, the ECU must be power-cycled. The flash
+   state is whatever it was when the kernel last ran.
+
+After a power cycle the ECU boots from flash. If an interrupted flash left
+blocks in an inconsistent state, the ECU may not boot normally.
+
+**SH7055 F-ZTAT hardware recovery (board-level):** The SH7055 has a hardware
+boot ROM burned into silicon. Pulling the MD pins (JP1/JP2 on PCB) low at
+power-on puts the chip into a factory serial programming mode — it accepts a
+reflash program over the SCI serial interface and can recover from a completely
+blank or corrupted flash state. This requires opening the ECU enclosure.
+
+nisprog's selective flash never writes Block 0 (reset vectors and boot code)
+unless `f` (flash all) is confirmed — so a crash during a normal cal/code
+flash typically leaves the boot sector intact and the F-ZTAT path may not be
+needed.
+
+---
+
+## Scenario 4: USB cable reconnect without PC restart
+
+If the USB cable was unplugged and reconnected while nisprog was open:
+
+1. The serial port handle is invalid — exit and reopen nisprog.
+2. The kernel is still running in ECU RAM (ECU power was maintained).
+3. Follow Scenario 1.
+
+---
+
+## Scenario 5: PC reboot, ECU still powered
+
+Same as Scenario 1. The kernel survives indefinitely in RAM as long as
+ECU power is maintained and the watchdog timer inside the kernel is being
+serviced. The kernel's internal WDT kicks the hardware WDT continuously —
+if the kernel hangs internally, the hardware WDT will reset the ECU.
+
+---
+
+## Quick reference: recovery command sequence
+
+```
+# After crash — kernel still running in ECU RAM
+set speed 62500           # kernel comms speed
+nc                        # establish L2 session
+initk                     # sync to running kernel
+setkeys 0xXXXX 0xYYYY    # re-supply security keys
+setdev 7055               # re-set device type
+dm test.bin 0 0x1000     # short test dump to confirm stable comms
+# then continue flverif / flrom / dm as needed
+stopkernel                # when fully done — resets ECU
+```
+
+---
+
+## AI notes
+
+- **Never cut ECU power during a flash.** The kernel keeps running in RAM as
+  long as power is maintained. Use `initk` to reconnect without reuploading.
+- **`flverif` "write errors" in dry-run are expected** — it does not write
+  anything. The errors show which blocks would be changed.
+- **`setdev` must be re-set after reconnect** — it is not persisted across
+  nisprog sessions.
+- **Re-supply security keys after reconnect** — `setkeys` before any flash
+  operation. See [`security_access.md`](security_access.md).
+
+---
+
+## Prevention
+
+- Always run `flverif` before `flrom` to verify the ROM file is correct.
+- Run `nisrom --fix <rom>` on any patched ROM before flashing to verify and
+  correct checksums. A ROM with wrong checksums may cause ECU misbehaviour
+  even after a successful flash.
+- Never flash below 12.5V — keep a battery charger on the car throughout.
+- Keep the K-line cable connected throughout `flrom` — do not unplug.
+- Save `gk` output before starting — needed for reconnect without re-running `gk`.

--- a/docs/debug.md
+++ b/docs/debug.md
@@ -1,0 +1,177 @@
+# nisprog — Debug Submenu
+
+The `debug` submenu enables verbose tracing of K-line traffic at each
+protocol layer. Use it to diagnose adapter problems, timing issues, framing
+errors, and unexpected ECU responses.
+
+Enter the submenu by typing `debug` at `nisprog>`. Use `debug help` for
+the built-in list of subcommands.
+
+---
+
+## Debug levels and layers
+
+nisprog uses a layered OSI-style protocol stack:
+
+| Layer | What it covers |
+|-------|---------------|
+| L0 | Hardware driver — serial port open/close, byte-level TX/RX, baud rate changes |
+| L1 | Physical framing — 5-baud init, fast init, break generation, echo removal |
+| L2 | Protocol framing — KWP2000 packet assembly, header handling, timing (P1–P4) |
+| L3 | Service layer — SID parsing, negative response handling (rarely used) |
+| CLI | Command parser — useful for debugging ini file parsing issues |
+
+Each layer has an independent debug level that is a bitmask of event flags.
+
+### Debug flag values
+
+| Flag | Value | Events enabled |
+|------|-------|---------------|
+| `OPEN` | `0x01` | Port open events |
+| `CLOSE` | `0x02` | Port close events |
+| `READ` | `0x04` | Byte/message receive events |
+| `WRITE` | `0x08` | Byte/message transmit events |
+| `IOCTL` | `0x10` | Interface control calls (set speed, set break, etc.) |
+| `PROTO` | `0x20` | Protocol state machine events |
+| `INIT` | `0x40` | Initialisation sequence events |
+| `DATA` | `0x80` | Dump raw data bytes when READ or WRITE is also set |
+| `TIMER` | `0x100` | Timer and timing events |
+
+Set to `-1` to enable all flags for a layer. Set to `0` to disable.
+
+---
+
+## Debug subcommands
+
+| Command | Description |
+|---------|-------------|
+| `debug l0 <val>` | Set L0 (hardware driver) debug level |
+| `debug l1 <val>` | Set L1 (physical) debug level |
+| `debug l2 <val>` | Set L2 (framing) debug level |
+| `debug l3 <val>` | Set L3 (service) debug level |
+| `debug cli <val>` | Set CLI parser debug level |
+| `debug all <val>` | Set all layers to the same level |
+| `debug show` | Print current debug levels for all layers |
+| `debug l0test [testnum]` | Run dumb adapter signal tests (see below) |
+
+---
+
+## Common debug recipes
+
+### Full K-line byte trace
+
+Enables hex dumps of every byte sent and received on the K-line at the
+physical layer. The most useful setting for diagnosing comms problems:
+
+```
+debug l1 0x8C    # READ (0x04) + WRITE (0x08) + DATA (0x80)
+```
+
+Then run `nc` — you will see every byte exchanged during the init sequence
+and each request/response cycle.
+
+Disable:
+```
+debug l1 0
+```
+
+### Watch the init sequence
+
+```
+debug l1 0xCC    # INIT (0x40) + READ (0x04) + WRITE (0x08) + DATA (0x80)
+up
+nc
+```
+
+This shows the exact init pulse timing and the first bytes exchanged.
+
+### Protocol framing trace
+
+```
+debug l2 0xAC    # PROTO (0x20) + READ (0x04) + WRITE (0x08) + DATA (0x80)
+```
+
+Shows L2 packet assembly and disassembly — useful when the ECU returns
+unexpected negative responses or framing errors.
+
+### All layers, full verbosity
+
+```
+debug all -1
+```
+
+Very verbose. Use only when the above targeted traces are not sufficient.
+
+---
+
+## `debug l0test` — adapter signal tests
+
+`l0test` runs direct hardware tests on the dumb adapter without connecting
+to a vehicle. **Disconnect the OBD cable from the vehicle first.**
+
+Switch to the test driver first:
+```
+set interface DUMBT    # use the test driver (not DUMB)
+set port \\.\COM19
+set dumbopts 0x48
+debug l0test ?         # list available test numbers
+```
+
+Then run specific tests:
+```
+debug l0test 1    # send pulses on TXD (K-line) — check polarity and levels with a meter or scope
+debug l0test 2    # send pulses on RTS (L-line) — check L-line driver
+debug l0test 3    # DTR test
+```
+
+### Interpreting results
+
+- **K-line (TXD):** logic 1 = negative voltage (~−12V on RS-232 side). If your
+  meter shows positive voltage when idle, the optocoupler polarity may be
+  inverted. Try `LLINE_INV` (`0x10`) in dumbopts.
+- **L-line (RTS):** should swing between negative and positive voltage when
+  `USE_LLINE` (`0x01`) is active. No swing = L-line not wired or driver fault.
+- **Echo check (BLOCKDUPLEX):** send a byte on TXD and check whether RXD echoes
+  the same byte. Half-duplex cables will echo every transmitted byte on RXD —
+  `BLOCKDUPLEX` (`0x40`) removes these echoes automatically.
+
+After testing, switch back to the real driver:
+```
+set interface DUMB
+```
+
+---
+
+## Diagnosing common problems
+
+### `nc` times out — no response
+
+1. `debug l1 0x8C` + retry `nc` — look for any bytes being received.
+2. No bytes at all: cable not plugged in, wrong COM port, or adapter not
+   powered. Check `set port` and verify the port in Device Manager.
+3. Bytes received but framing wrong: check `dumbopts`. Try `0x68` if `0x48`
+   fails.
+4. Init bytes go out but ECU does not respond: try `set initmode 5baud` — some
+   ECUs need slow init.
+
+### Framing errors / bad duplex
+
+Enable `debug l1 0x8C` and inspect the received bytes. Half-duplex echo not
+being removed appears as duplicate bytes in the trace. Ensure `BLOCKDUPLEX`
+(`0x40`) is in `dumbopts`.
+
+### Negative response 0x22 (conditionsNotCorrect)
+
+ECU responded but refused the service. Common causes:
+- Security access not completed — run `gk` or `setkeys` before the failing command.
+- Engine running — some services only work with ignition on and engine off.
+- Wrong `addrtype` — use `phys` not `func` for flash/dump.
+
+### Speed mismatch after kernel load
+
+After `runkernel`, comms switch to 62500 bps. If you disconnect and reconnect:
+```
+set speed 62500    # must set this before nc when kernel is running
+```
+
+Without this, L1 will try to communicate at 10400 bps and get garbage.

--- a/docs/re_workflow.md
+++ b/docs/re_workflow.md
@@ -1,0 +1,239 @@
+# nisprog — Using nisprog for Reverse Engineering
+
+nisprog provides several capabilities useful during ECU reverse engineering:
+targeted memory reads, live RAM monitoring, raw KWP2000 request injection,
+and EEPROM access. None of these modify the ECU.
+
+---
+
+## Bench wiring (NS-H11B 112-pin connector)
+
+Minimum pins to power the ECU and establish K-line communication off the vehicle:
+
+| Pin | Function |
+|-----|----------|
+| 38 (A38) | Battery +12V constant |
+| 47 (B7) | Ignition +12V — bridge to +12V to simulate key-on |
+| 60 (B20) | ECU Ground |
+| 109 (C29) | ECU Ground |
+| 116 (C36) | Sensor Ground — required for sensor inputs |
+| **14 (A14)** | **K-Line (Consult/OBD) — connect your K-line adapter here** |
+
+K-line adapter connects to Pin 14 (A14). All nisprog operations go through this line.
+
+**Immobilizer (NATS and equivalents):** Some ECUs require an immobilizer confirm
+signal before allowing injection. On bench, the ECU will connect via K-line but
+will not inject (and may behave erratically) without the confirm. Either loop the
+confirm wire or use the immobilizer unit from the same vehicle. Check the FSM
+wiring diagram for your ECU to determine if an immobilizer is present.
+
+---
+
+## ROM dump for offline analysis
+
+A full dump is the starting point for any RE session. Plan for ~10 minutes for
+a 512 KB ROM via K-line at 10400 baud.
+
+> **If a dump runs for more than ~1 hour**, stop it and check `setdev`. Reading
+> past the actual ROM size causes nisprog to round-robin and become extremely
+> slow. `setdev 7055` = 512 KB, `setdev 7051` = 256 KB, `setdev 7058` = 1 MB —
+> the value must match your ECU or the dump length will be wrong.
+
+```
+nc
+gk
+setdev 7055
+runkernel npkern\npk_SH7055_35.bin
+dm rom_original.bin 0 0           # full dump — length 0 means "full ROM size"
+# or with explicit byte count:
+dm rom_original.bin 0 524288      # same result, 512 KB = 0x80000 bytes
+```
+
+Then load `rom_original.bin` into Ghidra for static analysis.
+Partial dumps are faster for targeted reads during active RE:
+
+```
+dm cal_zone.bin 0x10000 0x8000    # dump 32 KB at offset 0x10000
+dm ivt.bin 0x0 0x200              # dump interrupt vector table (512 B)
+```
+
+---
+
+## Live RAM reading: `watch`
+
+`watch <addr>` polls 4 bytes at a ROM or RAM address continuously and prints
+the value each loop. Press Enter to stop.
+
+Before the kernel is loaded it uses KWP2000 SID 0xAC (ReadMemoryByAddress —
+Nissan proprietary). After `runkernel` it uses the faster kernel RMBA protocol.
+
+### Use cases
+
+**Monitor a RAM variable live:**
+```
+# Watch a suspected knock counter or status flag at 0xFFFF6000
+runkernel npkern\npk_SH7055_35.bin
+watch 0xFFFF6000
+# Rev the engine and observe the value change
+```
+
+**Confirm a table address is live:**
+After identifying a cal table in Ghidra, watch its RAM mirror while changing
+operating conditions to verify the ECU is reading from that address:
+```
+watch 0xFFFF7200    # suspected LTFT base table in RAM
+```
+
+**BBRAM / self-learn monitoring:**
+Watch LTFT, STFT, idle relearn, VVT target values updating during an idle
+relearn cycle:
+```
+watch 0xFFFF8100    # suspected LTFT cell
+```
+
+**Patch verification:**
+After flashing a changed table, watch the RAM mirror to confirm the ECU is
+using the new values at runtime:
+```
+watch 0xFFFF6A00    # patched timing table
+```
+
+### Targeted range dump (faster than watch for larger areas)
+
+```
+# Dump 256 bytes of RAM around an address of interest
+dm ram_sample.bin 0xFFFF6000 0x100
+```
+
+---
+
+## Raw KWP2000 requests: `diag sr`
+
+`diag sr` sends raw ISO 14230 bytes to the ECU and prints the full response.
+Useful for probing vendor-specific SIDs, reading data by local identifier, and
+testing ECU responses without writing any driver code.
+
+### Reading data by local identifier (SID 0x21)
+
+```
+nc
+diag sr 0x21 0x01     # read local ID 0x01 (varies by ECU)
+diag sr 0x21 0x10     # read local ID 0x10
+```
+
+### ReadMemoryByAddress (SID 0xAC) — manual form
+
+The same SID that `watch` uses internally:
+
+```
+# Read 4 bytes at address 0xFFFF6000
+# SID 0xAC, addr high-byte first, then length
+diag sr 0xAC 0xFF 0xFF 0x60 0x00 0x04
+```
+
+### Read ECU ID (SID 0x1A)
+
+```
+diag sr 0x1A 0x81    # same request nc sends automatically; response = ECUID bytes
+```
+
+### Read stored DTCs (SID 0x18)
+
+```
+diag sr 0x18 0x02 0xFF 0x00    # readDiagnosticTroubleCodes, all, all
+```
+
+### Tester present / keep-alive
+
+```
+diag sr 0x3E    # send every ~4 s to prevent session timeout
+```
+
+### Probing unknown SIDs
+
+```
+# Try a vendor-specific SID
+diag sr 0x1A 0x82    # alternate local ID — observe whether ECU responds or NRC 0x11
+diag sr 0x1A 0x83
+```
+
+Negative responses return `0x7F <SID> <NRC>` where NRC values include:
+- `0x11` — serviceNotSupported (SID not recognised)
+- `0x12` — subFunctionNotSupported (SID recognised, sub-function invalid)
+- `0x22` — conditionsNotCorrect (service exists but preconditions not met)
+- `0x35` — invalidKey (security access failed)
+
+---
+
+## EEPROM read
+
+Some ECU data (VIN, adaptation values, relearn state) is stored in an SPI
+EEPROM separate from the main flash. Reading it requires finding the
+`eeprom_read()` function address in the ROM:
+
+```
+# 1. Find eeprom_read() using nisrom
+nisrom -l rom_original.bin    # prints eeprom_read() address if found
+
+# 2. Set the address in nisprog
+npconf eepr 0x35250    # example address
+
+# 3. Dump EEPROM (512 bytes typical)
+dm eeprom.bin 0 512 eep
+```
+
+The `eep` flag on `dm` tells nisprog to treat the address as EEPROM space
+rather than ROM/RAM address space. Requires kernel to be running.
+
+---
+
+## Connecting to other modules for diagnostic reads
+
+You can target ABS, SRS, BCM, TCM for KWP2000 reads by changing `destaddr`:
+
+```
+set destaddr 0x35    # SRS
+up
+nc
+diag sr 0x18 0x02 0xFF 0x00    # read SRS DTCs
+```
+
+This is useful during RE to understand what each module stores and which
+services it supports. Note: flash and fast dump (`dm` with kernel) only work
+with the ECM (`destaddr 0x10`).
+
+---
+
+## Comparing ROM regions before and after
+
+After flashing, dump the ECU and diff against the patched file to confirm
+exactly what changed:
+
+```
+dm post_flash.bin 0 0
+# On PC:
+fc /b backup.bin post_flash.bin        # Windows binary diff
+diff <(xxd backup.bin) <(xxd post_flash.bin)   # Linux
+```
+
+Or use `flverif` within nisprog — it reports which 64-byte blocks differ
+without requiring an external diff tool.
+
+## `flrom` with original ROM reference
+
+`flrom new.bin backup.bin` takes an optional second argument — the original
+(pre-patch) ROM. When supplied, nisprog determines which blocks to write by
+comparing `new.bin` against `backup.bin` (the original), rather than comparing
+`new.bin` against the current ECU flash content.
+
+```
+# Standard form — compares new ROM against current ECU flash:
+flrom patched.bin
+
+# Reference form — compares new ROM against your known-good original:
+flrom patched.bin backup.bin
+```
+
+Use the reference form when the ECU flash state is uncertain (e.g. after a
+partial flash) — it guarantees you're applying exactly the diff between your
+known-good dump and your new ROM, regardless of what's currently on the chip.

--- a/docs/security_access.md
+++ b/docs/security_access.md
@@ -1,0 +1,161 @@
+# nisprog — Security Access: gk vs setkeys
+
+Nissan KWP2000 ECUs require a security access challenge-response before
+allowing any read or write operation. nisprog implements this via two
+commands: `gk` (automatic keyset lookup) and `setkeys` (manual key supply).
+
+---
+
+## How security access works
+
+1. nisprog sends SID 0x27 subfunction 0x01 (requestSeed).
+2. ECU responds with a 4-byte seed.
+3. nisprog computes the response using the secret key algorithm and the s27k
+   (SID 27 key) specific to this ECU.
+4. nisprog sends SID 0x27 subfunction 0x02 (sendKey) with the computed response.
+5. ECU unlocks if the response matches.
+6. For write operations (flash), a second challenge using SID 0x36 and s36k
+   is required.
+
+The s27k and s36k are ECU-specific values derived from the ECU ID. They are
+not derivable from the ROM file alone — they must be known in advance or
+guessed from a database.
+
+---
+
+## `gk` — automatic key guess
+
+```
+nc          # connect first — ECUID is retrieved and stored
+gk          # attempt to guess keyset from bundled DB
+```
+
+`gk` scans a bundled database of known Nissan keysets, matched by ECUID
+prefix. On success it prints:
+
+```
+SID27 key = XXXXXXXX   SID36 key = YYYYYYYY
+```
+
+**Always record this output.** Some ECU variants do not cache the security
+session across reconnects. If you disconnect and reconnect, you will need to
+re-supply the keys with `setkeys` before flash operations will succeed.
+
+If `gk` fails ("keyset unknown"), the ECU variant is not in the bundled DB.
+Use `setkeys` with values from `nissutils keyset_lookup.py` or a community
+source.
+
+---
+
+## `setkeys` — manual key supply
+
+```
+setkeys <s27k> [<s36k>]
+```
+
+### Both keys known
+
+If you have both keys (e.g. from a previous `gk` run or from `keyset_lookup.py`):
+
+```
+setkeys 0xABCD1234 0x5678EFGH
+```
+
+nisprog uses these directly and confirms:
+```
+Now using SID27 key=ABCD1234, SID36 key1=5678EFGH
+```
+
+### s27k only — automatic s36k lookup
+
+If you supply only the s27k, nisprog looks it up in the known keyset DB to
+find the matching s36k:
+
+```
+setkeys 0xABCD1234
+```
+
+If the s27k matches a known keyset, nisprog resolves the s36k and confirms
+both:
+```
+Now using SID27 key=ABCD1234, SID36 key1=5678EFGH
+```
+
+If the s27k is not in the DB, nisprog will print:
+```
+Does not match a known keyset; you will need to provide both s27 and s36 keys
+```
+
+In that case, either find the s36k externally and supply both, or use `gk`
+again with a fresh connection to try the full brute-force search.
+
+---
+
+## When to use which
+
+| Scenario | Command |
+|----------|---------|
+| First time with this ECU | `nc` then `gk` — auto-detects and displays both keys |
+| Reconnecting in the same session after `nc` | Keys are still cached — no action needed |
+| Reconnecting in a new session with known s27k | `setkeys <s27k>` — looks up s36k from DB |
+| Reconnecting with both keys known | `setkeys <s27k> <s36k>` — fastest, no DB lookup |
+| `gk` fails (unknown ECU) | Find keys via community sources, then `setkeys <s27k> <s36k>` |
+| Crash recovery — kernel still running | Must re-supply keys before any flash; use `setkeys` |
+
+---
+
+## Workflow: recording keys for later use
+
+A safe dump session always captures the keys for later flashing:
+
+```
+nc
+gk
+# Output:
+#   SID27 key = 432EF55B   SID36 key = 27CD3964
+# Copy these to a file or your session notes.
+setdev 7055
+runkernel npkern\npk_SH7055_35.bin
+dm backup.bin 0 0
+stopkernel
+npdisc
+```
+
+Then in a later flash session, skip `gk` and supply the keys directly:
+
+```
+nc
+setkeys 0x432EF55B 0x27CD3964
+setdev 7055
+runkernel npkern\npk_SH7055_35.bin
+flverif patched_rom.bin
+flrom patched_rom.bin
+stopkernel
+npdisc
+```
+
+---
+
+## AI notes
+
+- **Always run `gk` and record the output before doing anything else.** Some
+  ECU variants do not cache the security session — if you disconnect and
+  reconnect, you must re-supply keys with `setkeys`. Losing the `gk` output
+  means the write step will fail with a security-access error that can look
+  like a comms problem.
+- **`gk` must run after `nc`** — it uses the ECUID retrieved on connect to
+  match against the keyset DB.
+- **`setkeys` with one argument** does a DB lookup by s27k to find the s36k.
+  If the s27k is unknown to the DB, both values must be supplied.
+
+---
+
+## Finding keys outside nisprog
+
+If `gk` fails, the ECU variant is not in nisprog's bundled keyset DB. Options:
+
+- Check community sources (nissutils ROM DB, romraider forums) for the ECUID prefix.
+- If the s27k is known from a community source, `setkeys <s27k>` will attempt to
+  resolve the s36k from the bundled DB. If that also fails, both values must be supplied.
+- If no keyset exists anywhere, the keys must be derived through other means
+  (hardware-level extraction or seed/key algorithm analysis).

--- a/docs/set_reference.md
+++ b/docs/set_reference.md
@@ -1,0 +1,191 @@
+# nisprog — Set Subcommand Reference
+
+Full reference for all `set` subcommands. At the interactive prompt use
+`set <param> <value>`; in `.ini` files write bare `<param> <value>` after a
+lone `set` line. Use `set show` to print all current values. Use `set <param>
+?` for inline help.
+
+---
+
+## `interface` — hardware driver
+
+| Name | Hardware | Notes |
+|------|----------|-------|
+| `DUMB` | Any dumb serial K-line cable (FT232, CP2102, CH340, optocoupler) | **Use this for all Nissan K-line work.** Anything without an ELM327 chip is DUMB. |
+| `ELM` | ELM327-based adapters | Smart interpreted adapter — very slow, flash/dump not supported. |
+| `BR1` | B. Roadman BR-1 | Dedicated KWP2000 hardware. Supports J1850/ISO9141/ISO14230. |
+| `MET16` | Multiplex Engineering T16 | Multi-protocol lab interface. |
+| `DUMBT` | Dumb interface test driver | Not for ECU comms — use `debug l0test` for signal checks. |
+
+**Selection rule:** if the cable has nothing other than a USB-serial bridge
+(FT232, CP2102, CH340, PL2303) it is `DUMB`. If it has an ELM327 chip
+(marked on PCB or in product listing) use `ELM`. When uncertain, `DUMB` is
+almost always correct.
+
+---
+
+## `dumbopts` — dumb adapter option flags
+
+`dumbopts` is a bitmask — set it to the sum of the flags you need.
+
+| Flag | Value | Description |
+|------|-------|-------------|
+| `USE_LLINE` | `0x01` | Drive the L-line (RTS pin) during 5-baud init. Only needed for cables with a separate L-line wire (some VAGtool clones). |
+| `CLEAR_DTR` | `0x02` | Hold DTR low (negative voltage) continuously. Unusual; default is DTR high. |
+| `SET_RTS` | `0x04` | Hold RTS high continuously. Unusual. Do not combine with `USE_LLINE`. |
+| `MAN_BREAK` | `0x08` | Force software-bitbanged 5bps break pulses. **Essential for USB-serial bridges** (CP2102, CH340, FT232). Enabled in default `0x48`. |
+| `LLINE_INV` | `0x10` | Invert L-line polarity. Use only with `USE_LLINE`; very rare. |
+| `FAST_BREAK` | `0x20` | Alternate fast-init: send `0x00` at 360 bps (≈25 ms) instead of a hardware break. Try this if `initmode fast` fails. |
+| `BLOCKDUPLEX` | `0x40` | Remove echoed bytes at the message level (half-duplex cleanup when P4=0). Enabled in default `0x48`. |
+
+**Common presets:**
+
+| Value | Flags | When to use |
+|-------|-------|-------------|
+| `0x48` | `MAN_BREAK \| BLOCKDUPLEX` | **Default. Works for virtually all USB K-line cables.** Start here. |
+| `0x49` | `MAN_BREAK \| BLOCKDUPLEX \| USE_LLINE` | Cable exposes an L-line that must be driven during 5-baud init. |
+| `0x68` | `MAN_BREAK \| BLOCKDUPLEX \| FAST_BREAK` | Fast init fails with `0x48`; try alternate break method. |
+| `0x08` | `MAN_BREAK` only | Full-duplex adapter (no echo removal needed). |
+
+**Troubleshooting sequence:**
+1. Start with `0x48` — correct for the vast majority of USB K-line cables.
+2. If `nc` returns framing errors or no response with `initmode fast`, try `0x68`.
+3. If the cable has a separate L-line wire, add `0x01` → `0x49`.
+4. Use `set interface DUMBT` + `debug l0test` to send test pulses on K and L
+   lines and verify adapter signal levels before connecting to the vehicle.
+
+---
+
+## `l1protocol` — physical layer
+
+Selects hardware framing. For Nissan MEC07 (SH7055) ECUs, set this explicitly
+alongside `l2protocol` — relying on auto-selection has been observed to cause
+connection failures on some adapters.
+
+| Value | Description |
+|-------|-------------|
+| `ISO9141` | ISO 9141 physical framing (UART at 10400 bps, 5-baud wake-up). Older ECUs. |
+| `ISO14230` | KWP2000 physical framing. **Set this explicitly for Nissan MEC07 K-line.** |
+| `J1850-VPW` | SAE J1850 Variable Pulse Width. Pre-2003 GM/Chrysler. Not Nissan. |
+| `J1850-PWM` | SAE J1850 Pulse Width Modulation. Pre-2003 Ford. Not Nissan. |
+| `CAN` | ISO 15765 CAN. Not used by nisprog (K-line only tool). |
+| `RAW` | Raw byte passthrough — no framing. Required for Subaru SSM (`l2protocol raw`). |
+
+Use `set l1protocol ?` to list compiled-in choices.
+
+---
+
+## `l2protocol` — software / framing layer
+
+Must match the ECU's protocol dialect. Use `set l2protocol ?` to list what
+is compiled into your binary.
+
+| Value | Description |
+|-------|-------------|
+| `iso14230` | KWP2000 (ISO 14230-4). **Required for all Nissan ECU operations.** Provides security access (SID 27/36), ReadMemoryByAddress (SID 0xAC), and the service layer that `gk`, `nc`, `flrom`, and `dm` depend on. |
+| `raw` | Raw L1 passthrough — no L2 framing. Required for Subaru SSM (`ssmprog.ini`). |
+| `iso9141` | ISO 9141-2. Older OBD-II protocol; no security access SID. Diagnostic reads only. |
+
+---
+
+## `initmode` — bus wake-up sequence
+
+Controls how nisprog wakes up the ECU on the K-line.
+
+| Value | Description |
+|-------|-------------|
+| `fast` | **ISO 14230 fast init.** Pulls K-line low for 25 ms then sends StartCommunications (0xC1 0x33 0xF1). Fast (< 1 s). **Correct for Nissan MEC07 and most modern Nissan ECUs.** |
+| `5baud` | ISO 9141 / KWP2000 slow init. Sends ECU address at 5 bps before starting. Slower (~3 s). Use for older ECUs that do not respond to fast init. |
+| `carb` | CARB OBD-II functional init. For OBD-II emission scanners. Not used for Nissan flash/dump. |
+
+If `nc` times out or returns no response with `initmode fast`, try `initmode 5baud`.
+
+---
+
+## `testerid` — source address
+
+The source address placed in K-line frame headers. `0xfc` is the standard
+tester ID for nisprog and should not need to change.
+
+---
+
+## `destaddr` and `addrtype` — module targeting
+
+### addrtype phys (physical addressing)
+
+Packet targets exactly the module at `destaddr`. Required for flash, dump,
+security access, and all standard nisprog operations.
+
+### addrtype func (functional addressing)
+
+Packet is broadcast to address `0x33` (ISO 14230 functional address) regardless
+of `destaddr`. All modules supporting the requested service respond. Used by
+OBD-II scan tools to discover available modules. Not suitable for flash/dump.
+
+### Known Nissan KWP2000 module addresses (K-line)
+
+| Address | Module |
+|---------|--------|
+| `0x10` | ECM / PCM — powertrain. **Flash and dump target.** |
+| `0x14` | TCM — automatic transmission control |
+| `0x15` | ABS / VDC |
+| `0x28` | BCM — body control |
+| `0x35` | SRS / airbag |
+
+> Addresses vary by model year and market. Use `diag fastprobe 0x10 0x50` to
+> scan a range and identify responding modules on your specific vehicle.
+
+### Connecting to other modules (SRS, ABS, BCM)
+
+Change `destaddr` to the module's address and use `diag sr` for KWP2000 reads:
+
+```
+set destaddr 0x35    # target SRS/airbag
+up
+nc
+diag sr 0x18 0x02 0xFF 0x00    # read stored DTCs (SID 0x18)
+diag sr 0x14 0xFF 0x00         # clear DTCs (SID 0x14)
+```
+
+**Flash and dump operations cannot target non-ECM modules.** The npkern flash
+kernel only runs in ECM RAM. `flrom`, `flblock`, and fast `dm` only apply to
+the powertrain ECM (`destaddr 0x10`).
+
+---
+
+## `speed` — baud rate
+
+Serial port baud rate. Set automatically to 10400 bps for normal K-line
+operation. Only change to `62500` when reconnecting to an already-running
+kernel after a crash:
+
+```
+set speed 62500    # kernel comms baud rate
+nc
+initk              # re-initialise kernel comms without reuploading
+```
+
+See [`crash_recovery.md`](crash_recovery.md) for the full crash reconnect procedure.
+
+---
+
+## AI notes
+
+- **`setdev` accepts `7051`, `7055`, `7058` only.** `7055_18` and `7055_35`
+  appear in kernel *filenames* but are not valid setdev arguments. For any
+  SH7055 ECU, always `setdev 7055`.
+- **`set` prefix at the prompt vs ini:** `set l2protocol iso14230` is correct
+  at `nisprog>`. In `.ini` files, the bare `l2protocol iso14230` form (no
+  prefix) is correct inside the set submenu block. Mixing the two forms is
+  the most common configuration error.
+- **Connecting to non-ECM modules for diagnostics** (SRS, ABS) is possible by
+  changing `destaddr`. Flash and fast dump operations cannot target non-ECM
+  modules — the kernel only runs in ECM RAM.
+
+---
+
+## `show` — display current settings
+
+`set show` prints all current parameters including L0-layer adapter state.
+Run after loading an ini file to verify everything is configured correctly
+before `nc`.


### PR DESCRIPTION
Add comprehensive usage documentation for nisprog:

USAGE.md — top-level quick reference
  - Two-syntax connection settings (ini submenu vs interactive prompt)
  - Full command tables: connection, security, dump, flash kernel, flash, diagnostics
  - Annotated ini workflow examples for dump and flash sessions
  - Set quick-reference table

docs/set_reference.md — full set subcommand reference
  - Interface names and selection guide (DUMB/ELM/BR1/MET16/DUMBT)
  - dumbopts bitmask table with common presets (0x48/0x49/0x68)
  - l1protocol, l2protocol, initmode, speed, addrtype reference
  - Known Nissan KWP2000 module addresses

docs/security_access.md — gk vs setkeys
  - Security access challenge-response flow
  - When to use gk vs setkeys, s27k-only DB lookup
  - Key recording workflow for dump → flash sessions

docs/crash_recovery.md — recovery procedures
  - Five scenarios: nisprog crash with kernel running, flash interrupted, kernel hang, USB reconnect, PC reboot
  - SH7055 F-ZTAT hardware recovery via MD pin mode (board-level)
  - Prevention: voltage requirements, nisrom --fix

docs/re_workflow.md — reverse engineering use cases
  - Bench wiring (NS-H11B 112-pin minimum pins)
  - ROM dump, partial dumps, live RAM watch, diag sr recipes
  - EEPROM read, module probing, ROM diff with flverif

docs/debug.md — debug submenu and diagnostics
  - Debug flag bitmask table (L0–L3 layers)
  - Common recipes: K-line byte trace, init sequence, protocol trace
  - l0test procedure and common problem diagnostics